### PR TITLE
Force Middleman to use patched version of Rake

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,8 @@
 source 'https://rubygems.org'
 
+# Force middleman to use patched version of rake
+gem 'rake', '~> 12.3.3'
+
 # Middleman
 gem 'middleman', '~>4.1.0'
 gem 'middleman-syntax', '~> 3.0.0'


### PR DESCRIPTION
Included requirement for Rake at least 12.3.3, while Middleman only
requires above 12.3
Issue: BPN-2847
https://beyonic.atlassian.net/browse/BPN-2847

!!!!! STOP AND READ !!!!!

If the dropdown above says "base fork: lord/master", you are submitting your change to ALL USERS OF SLATE, not just your company. This is probably not what you want. Click "base fork" to change it to the right place.

If you're actually trying to submit a change to upstream Slate, please submit to our dev branch, PRs sent to the master branch are generally rejected.
